### PR TITLE
Add flush after header sent

### DIFF
--- a/src/Emitter/SapiStreamEmitter.php
+++ b/src/Emitter/SapiStreamEmitter.php
@@ -42,6 +42,8 @@ class SapiStreamEmitter implements EmitterInterface
         $this->emitHeaders($response);
         $this->emitStatusLine($response);
 
+        flush();
+
         $range = $this->parseContentRange($response->getHeaderLine('Content-Range'));
 
         if (null === $range || 'bytes' !== $range[0]) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

This patch makes it possible to send the headers before the content is sent to the
client, so they can already be processed and evaluated before the first results
show up.

This is especially interesting when having big streamed responses, like a csv
report. It also makes it possible to implement one shot server sent events.

There is no change in using the components. 
