### PR TITLE
Remove dependency on laminas/laminas-zendframework-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/http-server-handler": "^1.0"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I see that this package was added in https://github.com/laminas/laminas-httphandlerrunner/commit/a0f34185501fe257b0f18eb97e9e6734bfb0a425. However, I dont understand why. I also notice that the code is not using anything from the `Laminas\ZendFrameworkBridge` namespace. 

I am probably missing something, but I would like to open up for a discussion. 

I really like the `laminas/laminas-httphandlerrunner` package because it does its task really well. 