### PR TITLE
Fix function_exists() check in SapiEmitterTrait

### DIFF
--- a/src/Emitter/SapiEmitterTrait.php
+++ b/src/Emitter/SapiEmitterTrait.php
@@ -115,7 +115,7 @@ trait SapiEmitterTrait
 
     private function header(string $headerName, bool $replace, int $statusCode): void
     {
-        if (function_exists('Laminas\HttpHandlerRunner\Emitter\headers_sent')) {
+        if (function_exists('Laminas\HttpHandlerRunner\Emitter\header')) {
             // phpcs:ignore SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
             \Laminas\HttpHandlerRunner\Emitter\header($headerName, $replace, $statusCode);
             return;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This is an *obvious fix* for a copy and paste mistake.
    
Bug introduced in f41b72df527ad5cd9e1814fa62efc52271473f9c.

-------

This is a drive-by PR, because I noticed the issue while reading the source code. I do not (yet) have this library in production and thus no real interest in this project. Please move this across the finish line yourself in case there are any issues with this PR. Not signing off, because this is an obvious fix.