### PR TITLE
Option for ignoring the Content-Range header

### DIFF
--- a/src/Emitter/SapiStreamEmitter.php
+++ b/src/Emitter/SapiStreamEmitter.php
@@ -21,9 +21,13 @@ class SapiStreamEmitter implements EmitterInterface
     /** @var int Maximum output buffering size for each iteration. */
     private $maxBufferLength;
 
-    public function __construct(int $maxBufferLength = 8192)
+    /** @var bool Emit the full response body regardless of the Content-Range header. */
+    private $ignoreContentRange;
+
+    public function __construct(int $maxBufferLength = 8192, bool $ignoreContentRange = false)
     {
-        $this->maxBufferLength = $maxBufferLength;
+        $this->maxBufferLength    = $maxBufferLength;
+        $this->ignoreContentRange = $ignoreContentRange;
     }
 
     /**
@@ -40,7 +44,7 @@ class SapiStreamEmitter implements EmitterInterface
 
         flush();
 
-        $range = $this->parseContentRange($response->getHeaderLine('Content-Range'));
+        $range = $this->ignoreContentRange ? null : $this->parseContentRange($response->getHeaderLine('Content-Range'));
 
         if (null === $range || 'bytes' !== $range[0]) {
             $this->emitBody($response);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

When the response body has already been limited to the requested range, the emitter should ignore the Content-Range header and emit the full response body.

Fixes #22