### PR TITLE
Support PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-message-implementation": "^1.0",
@@ -35,10 +35,10 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-diactoros": "^2.1.1",
-        "phpunit/phpunit": "^9.3",
-        "psalm/plugin-phpunit": "^0.15.1",
-        "vimeo/psalm": "^4.6"
+        "laminas/laminas-diactoros": "^2.8.0",
+        "phpunit/phpunit": "^9.5.9",
+        "psalm/plugin-phpunit": "^0.16.1",
+        "vimeo/psalm": "^4.10.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.2@bca09d74adc704c4eaee36a3c3e9d379e290fc3b">
+<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
   <file src="src/Emitter/EmitterStack.php">
     <MixedArgument occurrences="1">
       <code>$index</code>
@@ -10,6 +10,11 @@
     <MixedMethodCall occurrences="1">
       <code>emit</code>
     </MixedMethodCall>
+    <UndefinedAttributeClass occurrences="3">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
     <UndefinedDocblockClass occurrences="3">
       <code>InvalidArgumentException</code>
       <code>InvalidArgumentException</code>
@@ -20,9 +25,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>headers_sent()</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="1">
-      <code>assertNoPreviousOutput</code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$header</code>
     </MixedArgumentTypeCoercion>
@@ -34,19 +36,19 @@
       <code>$length</code>
       <code>$remaining</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="3">
       <code>$length</code>
+      <code>$remaining</code>
       <code>$remaining</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
       <code>$last</code>
       <code>$remaining</code>
     </MixedOperand>
-  </file>
-  <file src="src/Exception/InvalidEmitterException.php">
-    <MissingParamType occurrences="1">
-      <code>$emitter</code>
-    </MissingParamType>
+    <UnusedVariable occurrences="2">
+      <code>$length</code>
+      <code>$unit</code>
+    </UnusedVariable>
   </file>
   <file src="src/RequestHandlerRunner.php">
     <MixedArgument occurrences="2">
@@ -66,44 +68,7 @@
       <code>$serverRequestFactory()</code>
     </MixedReturnStatement>
   </file>
-  <file src="test/ConfigProviderTest.php">
-    <MissingReturnType occurrences="2">
-      <code>testInvocationReturnsArray</code>
-      <code>testReturnedArrayContainsDependencies</code>
-    </MissingReturnType>
-    <MixedFunctionCall occurrences="1">
-      <code>($this-&gt;provider)()</code>
-    </MixedFunctionCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;provider</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;provider</code>
-    </UndefinedThisPropertyFetch>
-  </file>
-  <file src="test/Emitter/AbstractEmitterTest.php">
-    <MissingReturnType occurrences="5">
-      <code>testDoesNotInjectContentLengthHeaderIfStreamSizeIsUnknown</code>
-      <code>testDoesNotLetResponseCodeBeOverriddenByPHP</code>
-      <code>testEmitsMessageBody</code>
-      <code>testEmitsResponseHeaders</code>
-      <code>testMultipleSetCookieHeadersAreNotReplaced</code>
-    </MissingReturnType>
-  </file>
   <file src="test/Emitter/EmitterStackTest.php">
-    <MissingReturnType occurrences="11">
-      <code>nonEmitterValues</code>
-      <code>testCannotPushNonEmitterToStack</code>
-      <code>testCannotSetNonEmitterToSpecificIndex</code>
-      <code>testCannotUnshiftNonEmitterToStack</code>
-      <code>testEmitLoopsThroughEmittersUntilOneReturnsTrueValue</code>
-      <code>testEmitReturnsFalseIfLastEmmitterReturnsFalse</code>
-      <code>testEmitReturnsFalseIfNoEmittersAreComposed</code>
-      <code>testIsAnEmitterImplementation</code>
-      <code>testIsAnSplStack</code>
-      <code>testOffsetSetReplacesExistingValue</code>
-      <code>testUnshiftAddsNewEmitter</code>
-    </MissingReturnType>
     <MixedArgument occurrences="3">
       <code>$value</code>
       <code>$value</code>
@@ -166,6 +131,10 @@
       <code>$first</code>
       <code>$last</code>
     </PossiblyUndefinedVariable>
+    <UnusedVariable occurrences="2">
+      <code>$length</code>
+      <code>$unit</code>
+    </UnusedVariable>
   </file>
   <file src="test/RequestHandlerRunnerTest.php">
     <MissingClosureParamType occurrences="2">
@@ -182,40 +151,23 @@
       <code>function (Throwable $e) use ($response) {</code>
       <code>function (Throwable $e) {</code>
     </MissingClosureReturnType>
-    <MissingReturnType occurrences="4">
-      <code>testRaisesTypeErrorIfServerErrorResponseGeneratorFactoryDoesNotReturnAResponse</code>
-      <code>testRaisesTypeErrorIfServerRequestFactoryDoesNotReturnARequestInstance</code>
-      <code>testRunPassesRequestGeneratedByRequestFactoryToHandleWhenNoRequestPassedToRun</code>
-      <code>testUsesErrorResponseGeneratorToGenerateResponseWhenRequestFactoryRaisesException</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/TestAsset/HeaderStack.php">
-    <MissingReturnType occurrences="2">
-      <code>push</code>
-      <code>reset</code>
-    </MissingReturnType>
+    <UnusedClosureParam occurrences="1">
+      <code>$e</code>
+    </UnusedClosureParam>
   </file>
   <file src="test/TestAsset/MockStreamHelper.php">
-    <MissingParamType occurrences="1">
-      <code>$contents</code>
-    </MissingParamType>
     <MixedArgument occurrences="2">
       <code>$data</code>
       <code>$remainingContents</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$data</code>
       <code>$remainingContents</code>
-      <code>$this-&gt;contents</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>string</code>
-      <code>string</code>
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
-      <code>$data</code>
-      <code>$remainingContents</code>
+    <MixedReturnStatement occurrences="1">
       <code>is_callable($this-&gt;contents) ? ($this-&gt;contents)(0) : $this-&gt;contents</code>
     </MixedReturnStatement>
   </file>

--- a/src/Emitter/EmitterStack.php
+++ b/src/Emitter/EmitterStack.php
@@ -12,6 +12,7 @@ namespace Laminas\HttpHandlerRunner\Emitter;
 
 use Laminas\HttpHandlerRunner\Exception;
 use Psr\Http\Message\ResponseInterface;
+use ReturnTypeWillChange;
 use SplStack;
 
 /**
@@ -53,6 +54,7 @@ class EmitterStack extends SplStack implements EmitterInterface
      * @return void
      * @throws InvalidArgumentException if not an EmitterInterface instance
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $emitter)
     {
         $this->validateEmitter($emitter);
@@ -66,6 +68,7 @@ class EmitterStack extends SplStack implements EmitterInterface
      * @return void
      * @throws InvalidArgumentException if not an EmitterInterface instance
      */
+    #[ReturnTypeWillChange]
     public function push($emitter)
     {
         $this->validateEmitter($emitter);
@@ -79,6 +82,7 @@ class EmitterStack extends SplStack implements EmitterInterface
      * @return void
      * @throws InvalidArgumentException if not an EmitterInterface instance
      */
+    #[ReturnTypeWillChange]
     public function unshift($emitter)
     {
         $this->validateEmitter($emitter);


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
This patch introduces PHP 8.1 support, and bumps all dev-dependencies,
so that we are sure that the whole stack is PHP 8.1-compatible.
