### PR TITLE
Fix Content-Range response when body size equals expected range length

### DIFF
--- a/src/Emitter/SapiStreamEmitter.php
+++ b/src/Emitter/SapiStreamEmitter.php
@@ -86,7 +86,7 @@ class SapiStreamEmitter implements EmitterInterface
         $length = $last - $first + 1;
 
         if ($body->isSeekable()) {
-            $body->seek($first);
+            $body->seek($body->getSize() === $length ? 0 : $first);
 
             $first = 0;
         }

--- a/test/Emitter/SapiStreamEmitterTest.php
+++ b/test/Emitter/SapiStreamEmitterTest.php
@@ -608,6 +608,33 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         self::assertSame($expected, ob_get_clean());
     }
 
+    /**
+     * @psalm-return array<array-key, array{0: string, 1: string, 2: string}>
+     */
+    public function ignoreContentRangeProvider(): array
+    {
+        return [
+            ['bytes 0-2/*', 'Hel', 'Hel'],
+            ['bytes 3-6/*', 'lo w', 'lo w'],
+            ['items 0-0/1', 'Hello world', 'Hello world'],
+        ];
+    }
+
+    /**
+     * @dataProvider ignoreContentRangeProvider
+     */
+    public function testIgnoreContentRange(string $header, string $body, string $expected): void
+    {
+        $response = (new Response())
+            ->withHeader('Content-Range', $header);
+
+        $response->getBody()->write($body);
+
+        ob_start();
+        $this->emitter->emit($response);
+        self::assertSame($expected, ob_get_clean());
+    }
+
     public function testContentRangeUnseekableBody(): void
     {
         $body     = new CallbackStream(function () {


### PR DESCRIPTION
Signed-off-by: Antonio J. García Lagar <ajgarcia@c17.net>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

When the response body has already been limited to the requested range, the emitter should ignore the Content-Range header and emit the full response body.

This is an alternative to #23 to fix #22 