### PR TITLE
Drop require for psr-7 message implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "psr/http-message-implementation": "^1.0",
         "psr/http-server-handler": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2933f56c16d5522cea7f6dae6318ec84",
+    "content-hash": "0115cdcd48f51c8d2ccc56cfe82c8468",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Dependency on PSR-7 message implementation meta-package is superfluous. If no implementation provided this package will not be in incomplete state.